### PR TITLE
Fix for command format AUTH [username] [password]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Parameters:
 -n DB - Select the database DB.
 -r N - Repeat command N times.
 -a PASSWORD - Authentication password
+   OR -a "USERNAME PASSWORD" - Authentication username & password in double quotes
 -i INTERVAL - Interval between commands
 ```
 

--- a/redis-bash-cli
+++ b/redis-bash-cli
@@ -36,7 +36,7 @@ else
     echo "Wrong arguments"
     exit 255
 fi
-[ "${AUTH}" != "" ] && redis-client 6 AUTH "$AUTH" > /dev/null
+[ "${AUTH}" != "" ] && redis-client 6 AUTH $AUTH > /dev/null
 [ "${REDISDB}" != "" ] && redis-client 6 SELECT "$REDISDB" > /dev/null
 for ((z=1;z<=${REPEAT};z++))
 do


### PR DESCRIPTION
Usage: -a "username password" or -a "password" or -a password Removed double quotes to support passing username argument along with password